### PR TITLE
Alterações pontuais em evasao.sh e README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # script-shell-dados
-## O documento .tar.gz a ser descompactado deve se encontrar na pasta ~/Documentos para o funcionamento do script
+
 Shell script de processamento de dados, feito especificamente para o tipo de arquivo da entrada. Lê arquivos .csv com dados e faz uma série de leituras, tabelas e gráficos (Gnuplot).
 
-O objetivo deste trabalho é fazer um script chamado evasao.sh que:
+O objetivo deste trabalho é fazer um script chamado `evasao.sh` que:
 
 1. Leia todos os arquivos do diretório descompactado da extração do arquivo evasao2014-18.tar.gz
 

--- a/evasao.sh
+++ b/evasao.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ~/Documentos
+
 tar -xvf evasao2014-18.tar.gz
 cd evasao
 
@@ -110,8 +110,5 @@ EOF
 
 rm qnt_anos.txt
 rm evasao.txt
-for ((i=4;i<=8;i++)) ; do
-rm evasao-201$i.csv
 rm evasao_temp.txt
-done
-
+for ((i=4;i<=8;i++)) ; do rm evasao-201$i.csv; done


### PR DESCRIPTION
O script não mais necessita que o arquivo tarball esteja em
~/Documentos, portanto o README foi alterado para refletir a mudança.

Loop final de remoção de arquivos consertado.